### PR TITLE
chore: atualiza endpoint da api no swagger

### DIFF
--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -9,7 +9,7 @@ const swaggerDefinition = {
   },
   servers: [
     {
-      url: 'http://localhost:3000',
+      url: 'http://localhost:3000/api',
       description: 'Servidor local'
     }
   ],


### PR DESCRIPTION
o endpoint do swagger não estava funcionando pois estava faltando o /api.